### PR TITLE
mention method=ext-jwt

### DIFF
--- a/management.yml
+++ b/management.yml
@@ -655,7 +655,7 @@ paths:
     post:
       security: []
       description: |
-        Allows authentication  Methods include "password" and "cert"
+        Allowed authentication methods include "password", "cert", and "ext-jwt"
       tags:
       - Authentication
       summary: Authenticate via a method supplied via a query string parameter


### PR DESCRIPTION
Neither Postman nor Insomnia parses the enum of valid args to the `method` query param from the spec. Insomnia, at least, displays the description quite visibly. This mentions the third valid method in the description to make that option more visible.