### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.49
+          version: v1.53.3
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,83 @@
+# options for analysis running
+run:
+  modules-download-mode: mod
+linters-settings:
+  depguard:
+    rules:
+      # Name of a rule.
+      main:
+        # List of file globs that will match this list of settings to compare against.
+        files:
+          - $all
+        # List of allowed packages.
+        allow:
+          - $gostd
+          - github.com/openziti
+          - github.com/go-openapi
+          - github.com/fullsailor/pkcs7
+        # Packages that are not allowed where the value is a suggestion.
+        deny:
+          - pkg: "github.com/sirupsen/logrus"
+            desc: not allowed
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
+  funlen:
+    lines: 300
+    statements: 300
+  gocyclo:
+    min-complexity: 40
+  dupl:
+    threshold: 150
+  misspell:
+    locale: US
+  lll:
+    line-length: 190
+  goimports:
+    local-prefixes: github.com/golangci/golangci-lint
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - whyNoLint
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - dogsled
+    - depguard
+    - dupl
+    - errcheck
+    - exportloopref
+    - exhaustive
+    - funlen
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace

--- a/rest_util/authenticate.go
+++ b/rest_util/authenticate.go
@@ -22,27 +22,28 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net/http"
+	"net/url"
+
 	"github.com/go-openapi/runtime"
 	openapiclient "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 	"github.com/openziti/edge-api/rest_management_api_client"
 	"github.com/openziti/edge-api/rest_management_api_client/authentication"
 	"github.com/openziti/edge-api/rest_model"
-	"net/http"
-	"net/url"
 )
 
 // Authenticator is an interface that facilitates obtaining an API Session.
 type Authenticator interface {
-	//Authenticate issues an authentication HTTP requests to the designated controller. The method and operation
+	// Authenticate issues an authentication HTTP requests to the designated controller. The method and operation
 	// of this authentication request is determined by the implementor.
 	Authenticate(controllerAddress *url.URL) (*rest_model.CurrentAPISessionDetail, error)
 
-	//BuildHttpClient returns a http.Client to use for an API client. This specifically allows
-	//client certificate authentication to be configured in the http.Client's transport/tls.Config
+	// BuildHttpClient returns a http.Client to use for an API client. This specifically allows
+	// client certificate authentication to be configured in the http.Client's transport/tls.Config
 	BuildHttpClient() (*http.Client, error)
 
-	//SetInfo sets the env and sdk info submitted on Authenticate
+	// SetInfo sets the env and sdk info submitted on Authenticate
 	SetInfo(*rest_model.EnvInfo, *rest_model.SdkInfo)
 }
 

--- a/rest_util/clients.go
+++ b/rest_util/clients.go
@@ -36,17 +36,19 @@ package rest_util
 import (
 	"crypto"
 	"crypto/x509"
+	"net/http"
+	"net/url"
+
+	"errors"
+
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/openziti/edge-api/rest_client_api_client"
 	"github.com/openziti/edge-api/rest_management_api_client"
-	"github.com/pkg/errors"
-	"net/http"
-	"net/url"
 )
 
 // NewEdgeManagementClientWithToken will generate a new rest_management_api_client.ZitiEdgeManagement client based
 // upon a provided http.Client, controller address, and an API Session token that has been previously obtained.
-func NewEdgeManagementClientWithToken(httpClient *http.Client, apiAddress string, apiSessionToken string) (*rest_management_api_client.ZitiEdgeManagement, error) {
+func NewEdgeManagementClientWithToken(httpClient *http.Client, apiAddress, apiSessionToken string) (*rest_management_api_client.ZitiEdgeManagement, error) {
 	ctrlUrl, err := url.Parse(apiAddress)
 
 	if err != nil {
@@ -65,7 +67,7 @@ func NewEdgeManagementClientWithToken(httpClient *http.Client, apiAddress string
 // NewEdgeManagementClientWithUpdb will generate a new rest_management_api_client.ZitiEdgeManagement client based
 // upon a provided http.Client, controller address, and will authenticate via username/password database (updb)
 // to obtain an API Session token.
-func NewEdgeManagementClientWithUpdb(username, password string, apiAddress string, rootCas *x509.CertPool) (*rest_management_api_client.ZitiEdgeManagement, error) {
+func NewEdgeManagementClientWithUpdb(username, password, apiAddress string, rootCas *x509.CertPool) (*rest_management_api_client.ZitiEdgeManagement, error) {
 	auth := NewAuthenticatorUpdb(username, password)
 	auth.RootCas = rootCas
 	return NewEdgeManagementClientWithAuthenticator(auth, apiAddress)
@@ -74,7 +76,8 @@ func NewEdgeManagementClientWithUpdb(username, password string, apiAddress strin
 // NewEdgeManagementClientWithCert will generate a new rest_management_api_client.ZitiEdgeManagement client based
 // upon a provided http.Client, controller address, and will authenticate via client certificate to obtain
 // an API Session token.
-func NewEdgeManagementClientWithCert(cert *x509.Certificate, privateKey crypto.PrivateKey, apiAddress string, rootCas *x509.CertPool) (*rest_management_api_client.ZitiEdgeManagement, error) {
+func NewEdgeManagementClientWithCert(cert *x509.Certificate, privateKey crypto.PrivateKey, apiAddress string,
+	rootCas *x509.CertPool) (*rest_management_api_client.ZitiEdgeManagement, error) {
 	auth := NewAuthenticatorCert(cert, privateKey)
 	auth.RootCas = rootCas
 	return NewEdgeManagementClientWithAuthenticator(auth, apiAddress)
@@ -110,7 +113,7 @@ func NewEdgeManagementClientWithAuthenticator(authenticator Authenticator, apiAd
 
 // NewEdgeClientClientWithToken will generate a new rest_client_api_client.ZitiEdgeClient client based
 // upon a provided http.Client, controller address, and an API Session token that has been previously obtained.
-func NewEdgeClientClientWithToken(httpClient *http.Client, apiAddress string, apiSessionToken string) (*rest_client_api_client.ZitiEdgeClient, error) {
+func NewEdgeClientClientWithToken(httpClient *http.Client, apiAddress, apiSessionToken string) (*rest_client_api_client.ZitiEdgeClient, error) {
 	ctrlUrl, err := url.Parse(apiAddress)
 
 	if err != nil {
@@ -131,7 +134,7 @@ func NewEdgeClientClientWithToken(httpClient *http.Client, apiAddress string, ap
 // NewEdgeClientClientWithUpdb will generate a new rest_client_api_client.ZitiEdgeClient client based
 // upon a provided http.Client, controller address, and will authenticate via username/password database (updb)
 // to obtain an API Session token.
-func NewEdgeClientClientWithUpdb(username, password string, apiAddress string, rootCas *x509.CertPool) (*rest_client_api_client.ZitiEdgeClient, error) {
+func NewEdgeClientClientWithUpdb(username, password, apiAddress string, rootCas *x509.CertPool) (*rest_client_api_client.ZitiEdgeClient, error) {
 	auth := NewAuthenticatorUpdb(username, password)
 	auth.RootCas = rootCas
 	return NewEdgeClientClientWithAuthenticator(auth, apiAddress)

--- a/rest_util/errors.go
+++ b/rest_util/errors.go
@@ -18,6 +18,7 @@ package rest_util
 
 import (
 	"fmt"
+
 	"github.com/openziti/edge-api/rest_model"
 )
 

--- a/rest_util/util.go
+++ b/rest_util/util.go
@@ -18,11 +18,12 @@ package rest_util
 
 import (
 	"crypto/tls"
+	"net/http"
+	"time"
+
 	openApiRuntime "github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/openziti/edge-api/rest_model"
-	"net/http"
-	"time"
 )
 
 type HeaderAuth struct {
@@ -51,12 +52,16 @@ func (e *ZitiTokenAuth) AuthenticateRequest(request openApiRuntime.ClientRequest
 
 // NewHttpClientWithTlsConfig provides a default HTTP client with generous default timeouts.
 func NewHttpClientWithTlsConfig(tlsClientConfig *tls.Config) (*http.Client, error) {
+	const (
+		maxIdleConns = 10
+		timeout      = 10
+	)
 	httpClientTransport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		Proxy:                 http.ProxyFromEnvironment,
 		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          10,
-		IdleConnTimeout:       10 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
+		MaxIdleConns:          maxIdleConns,
+		IdleConnTimeout:       timeout * time.Second,
+		TLSHandshakeTimeout:   timeout * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
 
@@ -64,7 +69,7 @@ func NewHttpClientWithTlsConfig(tlsClientConfig *tls.Config) (*http.Client, erro
 
 	httpClient := &http.Client{
 		Transport: httpClientTransport,
-		Timeout:   10 * time.Second,
+		Timeout:   timeout * time.Second,
 	}
 	return httpClient, nil
 }


### PR DESCRIPTION
Hi

This commit just fix some trivial golangci-lint issues and also add a configuration file for its linters

Let me know what you think about it.

FYI: I also found that `io.ioutil` is still present on swagger-generated files
