### PR TITLE
normalize eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,42 +1,57 @@
-*.txt eol=lf
-*.gitignore text eol=lf
-*.sh text eol=lf
-*.md text eol=lf
-*.mod text eol=lf
-*.sum text eol=lf
-*.go text eol=lf
-*.yml text eol=lf
-*.proto text eol=lf
-*.json text eol=lf
-*.html text eol=lf
-*.svg text eol=lf
-*.js text eol=lf
-*.css text eol=lf
-*.yaml text eol=lf
-*.http text eol=lf
-*.ps1 text eol=lf
-*.g4 text eol=lf
-*.interp text eol=lf
-*.pem text eol=lf
-*.cnf text eol=lf
-*.conf text eol=lf
-*.gitmodules text eol=lf
-*.variants text eol=lf
-*.cmake text eol=lf
-*.bat text eol=lf
-*.env text eol=lf
-*.service text eol=lf
-*.tmpl text eol=lf
-*.partial text eol=lf
-*.liquid text eol=lf
-*.tokens text eol=lf
-*.attr text eol=lf
-*.in text eol=lf
-*.h text eol=lf
-*.c text eol=lf
-*.kts text eol=lf
-*.properties text eol=lf
-*.rst text eol=lf
-*.gradle text eol=lf
-*.java text eol=lf
-*.kt text eol=lf
+# Treat all text files as text, with automatic line-ending handling
+* text=auto
+
+# Explicitly mark certain text files
+*.attr text
+*.bat text
+*.cmake text
+*.cnf text
+*.conf text
+*.css text
+*.c text
+*.env text
+*.g4 text
+*.gitignore text
+*.gitmodules text
+*.go text
+*.gradle text
+*.h text
+*.html text
+*.http text
+*.interp text
+*.in text
+*.java text
+*.json text
+*.js text
+*.kts text
+*.kt text
+*.liquid text
+*.md text
+*.mod text
+*.partial text
+*.pem text
+*.properties text
+*.proto text
+*.ps1 text
+*.rst text
+*.service text
+*.sh text
+*.sum text
+*.svg text
+*.tmpl text
+*.tokens text
+*.txt text
+*.variants text
+*.yaml text
+*.yml text
+
+# Declare common binary file types
+*.docx binary
+*.exe binary
+*.gif binary
+*.jpg binary
+*.pdf binary
+*.png binary
+*.pptx binary
+*.xlsx binary
+*.zip binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Treat all text files as text, with automatic line-ending handling
-* text=auto
+# Treat all text files as text, with LF (Unix) line-endings on commit and checkout
+* text eol=lf
 
 # Explicitly mark certain text files
 *.attr text

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
-All open source projects managed by OpenZiti share a common [code of conduct](https://docs.openziti.io/policies/CODE_OF_CONDUCT.html) 
+All open source projects managed by OpenZiti share a common [code of conduct](https://docs.openziti.io/policies/CODE_OF_CONDUCT.html)
 which all contributors are expected to follow. Please be sure you read, understand and adhere to the guidelines expressed therein.


### PR DESCRIPTION
Fix line endings in Markdown files from CRLF to LF and set EOL for text files to auto to ensure only LF are committed while native EOL is used for clone, checkout, etc.